### PR TITLE
Fix restoring trashed memos after notebook deletion / 修复回收站笔记恢复到已删除笔记本

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1622,19 +1622,28 @@ app.post("/api/v1/memos/:id/restore", async (c) => {
 
   const tags = parseJsonArray(current.tags_json);
   const now = isoNow();
+  const originalNotebook = await getNotebook(c.env.DB, current.notebook_id);
+  const restoreNotebookId = originalNotebook ? current.notebook_id : "nb_inbox";
+
+  if (!originalNotebook && !(await getNotebook(c.env.DB, restoreNotebookId))) {
+    return conflict(c, "restore_notebook_missing", "Original notebook was deleted and the default inbox is unavailable.");
+  }
 
   await c.env.DB.batch([
     c.env.DB.prepare(
       `UPDATE memos
-       SET is_deleted = 0, deleted_at = NULL, updated_at = ?
+       SET notebook_id = ?, is_deleted = 0, deleted_at = NULL, updated_at = ?
        WHERE id = ? AND is_deleted = 1`
-    ).bind(now, id),
+    ).bind(restoreNotebookId, now, id),
     c.env.DB.prepare(`DELETE FROM memos_fts WHERE memo_id = ?`).bind(id),
     c.env.DB.prepare(
       `INSERT INTO memos_fts (memo_id, title, content_text, tags)
        VALUES (?, ?, ?, ?)`
     ).bind(id, current.title, current.content_text, tags.join(" ")),
-    auditStatement(c.env.DB, actor.actorType, actor.actorId, "memo.restore", "memo", id, {}),
+    auditStatement(c.env.DB, actor.actorType, actor.actorId, "memo.restore", "memo", id, {
+      fromNotebookId: current.notebook_id,
+      toNotebookId: restoreNotebookId,
+    }),
   ]);
 
   return c.json({ memo: await getMemoDetail(c.env.DB, id) });

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "preview:web": "vite preview --config apps/web/vite.config.ts --host 127.0.0.1 --port 4173",
     "preview:site": "bun --cwd apps/site preview",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test:restore-deleted-notebook": "bun scripts/test-restore-deleted-notebook.mjs",
     "db:migrate:local": "bun scripts/run-wrangler.mjs d1 migrations apply DB --local",
     "db:migrate:remote": "bun scripts/run-wrangler.mjs d1 migrations apply DB --remote",
     "auth:hash": "bun scripts/hash-password.mjs",

--- a/scripts/test-restore-deleted-notebook.mjs
+++ b/scripts/test-restore-deleted-notebook.mjs
@@ -1,0 +1,154 @@
+import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+import { globSync } from "node:fs";
+import { Database } from "bun:sqlite";
+import worker from "../apps/api/src/index.ts";
+
+class SqliteD1PreparedStatement {
+  constructor(db, sql, bindings = []) {
+    this.db = db;
+    this.sql = sql;
+    this.bindings = bindings;
+  }
+
+  bind(...bindings) {
+    return new SqliteD1PreparedStatement(this.db, this.sql, bindings);
+  }
+
+  async all() {
+    return {
+      results: this.db.query(this.sql).all(...this.bindings),
+      success: true,
+      meta: {},
+    };
+  }
+
+  async first() {
+    return this.db.query(this.sql).get(...this.bindings) ?? null;
+  }
+
+  async run() {
+    this.db.query(this.sql).run(...this.bindings);
+    return {
+      success: true,
+      meta: {},
+    };
+  }
+}
+
+class SqliteD1Database {
+  constructor(db) {
+    this.db = db;
+  }
+
+  prepare(sql) {
+    return new SqliteD1PreparedStatement(this.db, sql);
+  }
+
+  async batch(statements) {
+    const results = [];
+    this.db.transaction(() => {
+      for (const statement of statements) {
+        results.push(this.db.query(statement.sql).run(...statement.bindings));
+      }
+    })();
+    return results;
+  }
+}
+
+const applyMigrations = (db) => {
+  for (const file of globSync("migrations/*.sql").sort()) {
+    db.exec(readFileSync(file, "utf8"));
+  }
+};
+
+const createEnv = () => {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  applyMigrations(sqlite);
+
+  return {
+    sqlite,
+    env: {
+      DB: new SqliteD1Database(sqlite),
+      RESOURCES: {
+        delete: async () => undefined,
+        get: async () => null,
+        put: async () => undefined,
+      },
+    },
+  };
+};
+
+const fetchWorker = async (env, path, init = {}) =>
+  worker.fetch(
+    new Request(`https://edgeever.test${path}`, init),
+    env,
+    {
+      waitUntil: () => undefined,
+      passThroughOnException: () => undefined,
+    }
+  );
+
+const assertStatus = async (response, status) => {
+  if (response.status !== status) {
+    assert.fail(`Expected status ${status}, got ${response.status}: ${await response.text()}`);
+  }
+};
+
+const { sqlite, env } = createEnv();
+
+sqlite.run(
+  `INSERT INTO notebooks (id, parent_id, name, slug, icon, color, sort_order)
+   VALUES ('nb_bug', NULL, 'Bug Notebook', 'bug-notebook', 'notebook', '#000000', 99)`
+);
+sqlite.run(
+  `INSERT INTO memos (id, notebook_id, title, excerpt, tags_json, created_by, updated_by)
+   VALUES ('memo_bug', 'nb_bug', 'Bug Memo', 'Bug', '[]', 'test', 'test')`
+);
+sqlite.run(
+  `INSERT INTO memo_contents (memo_id, content_json, content_markdown, content_text, content_hash, revision)
+   VALUES (
+     'memo_bug',
+     '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Bug"}]}]}',
+     'Bug',
+     'Bug',
+     'hash',
+     0
+   )`
+);
+sqlite.run(
+  `INSERT INTO memos_fts (memo_id, title, content_text, tags)
+   VALUES ('memo_bug', 'Bug Memo', 'Bug', '')`
+);
+
+let response = await fetchWorker(env, "/api/v1/memos/memo_bug", { method: "DELETE" });
+await assertStatus(response, 200);
+
+response = await fetchWorker(env, "/api/v1/notebooks/nb_bug", { method: "DELETE" });
+await assertStatus(response, 200);
+
+response = await fetchWorker(env, "/api/v1/memos/memo_bug/restore", { method: "POST" });
+await assertStatus(response, 200);
+
+const body = await response.json();
+assert.equal(body.memo.id, "memo_bug");
+assert.equal(body.memo.isDeleted, false);
+assert.equal(body.memo.notebookId, "nb_inbox");
+
+const restored = sqlite
+  .query(
+    `SELECT m.notebook_id, m.is_deleted, deleted_notebook.is_deleted AS old_notebook_deleted
+     FROM memos m
+     INNER JOIN notebooks deleted_notebook ON deleted_notebook.id = 'nb_bug'
+     WHERE m.id = 'memo_bug'`
+  )
+  .get();
+
+assert.deepEqual(restored, {
+  notebook_id: "nb_inbox",
+  is_deleted: 0,
+  old_notebook_deleted: 1,
+});
+
+console.log("restore-deleted-notebook regression passed");


### PR DESCRIPTION
## Summary

- Fixes restoring a trashed memo whose original notebook has been soft-deleted.
- If the original notebook is no longer active, the memo is restored into the default inbox (`nb_inbox`) instead of keeping a dangling `notebook_id`.
- Adds audit metadata recording `fromNotebookId` and `toNotebookId` for restore actions.
- Adds a targeted regression script that exercises the Worker endpoints with an in-memory SQLite-backed D1 shim.

Fixes #6.

## 中文说明

- 修复“回收站笔记恢复到已删除笔记本”问题。
- 当原笔记本已经不是 active 状态时，将笔记恢复到默认收件箱/等待分类（`nb_inbox`），避免 active memo 指向 deleted notebook。
- 恢复审计日志中记录 `fromNotebookId` 与 `toNotebookId`，方便追踪自动落点。
- 新增一个轻量回归脚本，使用内存 SQLite 模拟 D1，并通过 Worker endpoint 跑完整流程。

关闭 #6。

## Tests

- `bun run test:restore-deleted-notebook`
- `bun run typecheck`
- `bun run build`
