### PR TITLE
fix: always load .env.local values in run-wrangler

### DIFF
--- a/scripts/run-wrangler.mjs
+++ b/scripts/run-wrangler.mjs
@@ -35,7 +35,7 @@ const loadLocalEnv = () => {
       value = value.slice(1, -1);
     }
 
-    if (key && process.env[key] === undefined) {
+    if (key) {
       process.env[key] = value;
     }
   }
@@ -189,6 +189,9 @@ const isDeployCommand = wranglerArgs.includes("deploy");
 const hasSecretsFileArg = wranglerArgs.some((arg) => arg === "--secrets-file" || arg.startsWith("--secrets-file="));
 const authPasswordHash = envValue("AUTH_PASSWORD_HASH");
 const finalWranglerArgs = [...wranglerArgs];
+
+console.log("FROM_ENV =", process.env.EDGE_EVER_AUTH_PASSWORD_HASH);
+console.log("ENV_VALUE =", authPasswordHash);
 
 if (isDeployCommand && authPasswordHash && !hasSecretsFileArg) {
   writeFileSync(generatedSecretsPath, `EDGE_EVER_AUTH_PASSWORD_HASH=${authPasswordHash}\n`);

--- a/scripts/run-wrangler.mjs
+++ b/scripts/run-wrangler.mjs
@@ -190,9 +190,6 @@ const hasSecretsFileArg = wranglerArgs.some((arg) => arg === "--secrets-file" ||
 const authPasswordHash = envValue("AUTH_PASSWORD_HASH");
 const finalWranglerArgs = [...wranglerArgs];
 
-console.log("FROM_ENV =", process.env.EDGE_EVER_AUTH_PASSWORD_HASH);
-console.log("ENV_VALUE =", authPasswordHash);
-
 if (isDeployCommand && authPasswordHash && !hasSecretsFileArg) {
   writeFileSync(generatedSecretsPath, `EDGE_EVER_AUTH_PASSWORD_HASH=${authPasswordHash}\n`);
   finalWranglerArgs.push("--secrets-file", generatedSecretsPath);


### PR DESCRIPTION
## Summary

When running with Bun, `.env.local` is automatically loaded into `process.env`
before `scripts/run-wrangler.mjs` executes.

For PBKDF2 hashes like:

```dotenv
EDGE_EVER_AUTH_PASSWORD_HASH=pbkdf2-sha256$100000$...
```

Bun preloads the value as:

```
pbkdf2-sha256
```

As a result, `loadLocalEnv()` skips overriding the existing environment
variable because of:

```js
if (process.env[key] === undefined) {
  process.env[key] = value;
}
```

This causes:

- `.env.wrangler.generated.secrets` to contain only `pbkdf2-sha256`
- `wrangler secret put` to upload an invalid password hash
- authentication to always fail after deployment.

## Fix

Always overwrite `process.env` with the value parsed from `.env.local`.

This keeps the custom parser authoritative and avoids runtime-specific behavior
introduced by Bun's automatic dotenv loading.

## Reproduction

1. Put a PBKDF2 hash into `.env.local`

```
EDGE_EVER_AUTH_PASSWORD_HASH=pbkdf2-sha256$100000$...
```

2. Run

```
bun run deploy
```

Before this change:

```
.env.wrangler.generated.secrets

EDGE_EVER_AUTH_PASSWORD_HASH=pbkdf2-sha256
```

After this change:

```
EDGE_EVER_AUTH_PASSWORD_HASH=pbkdf2-sha256$100000$...
```