### PR TITLE
fix: markdownToDoc now parses inline formatting (bold, italic, code, strikethrough, links)

### DIFF
--- a/packages/shared/src/content.ts
+++ b/packages/shared/src/content.ts
@@ -1,6 +1,12 @@
+export type TiptapMark = {
+  type: "bold" | "italic" | "code" | "strike" | "link";
+  attrs?: Record<string, unknown>;
+};
+
 export type TiptapTextNode = {
   type: "text";
   text: string;
+  marks?: TiptapMark[];
 };
 
 export type TiptapNode = {
@@ -20,6 +26,117 @@ export const emptyDoc = (): TiptapDoc => ({
   type: "doc",
   content: [{ type: "paragraph" }],
 });
+
+const parseInlineMarkdown = (text: string): TiptapTextNode[] => {
+  if (!text) {
+    return [];
+  }
+
+  const nodes: TiptapTextNode[] = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    // Try to find the earliest inline markdown match
+    const boldItalicMatch = remaining.match(/^\*\*\*([\s\S]*?)\*\*\*/);
+    const boldMatch = remaining.match(/^\*\*([\s\S]*?)\*\*/);
+    const italicMatch = remaining.match(/^\*([^*].*?)\*/);
+    const boldUMatch = remaining.match(/^__([\s\S]*?)__/);
+    const italicUMatch = remaining.match(/^_([^_].*?)_/);
+    const strikeMatch = remaining.match(/^~~([\s\S]*?)~~/);
+    const codeMatch = remaining.match(/^`([^`]+)`/);
+    const imageMatch = remaining.match(/^!\[([^\]]*)\]\((\S+?)(?:\s+"([^"]+)")?\)/);
+    const linkMatch = remaining.match(/^\[([^\]]+)\]\(([^)]+)\)/);
+
+    // Find the earliest match (smallest index is 0 since we use ^ anchors)
+    // Prioritize longer markers first to avoid * matching inside **
+    type MatchResult = { type: string; match: RegExpMatchArray; length: number };
+    const matches: MatchResult[] = [];
+
+    if (boldItalicMatch) matches.push({ type: "boldItalic", match: boldItalicMatch, length: boldItalicMatch[0].length });
+    if (boldMatch) matches.push({ type: "bold", match: boldMatch, length: boldMatch[0].length });
+    if (italicMatch) matches.push({ type: "italic", match: italicMatch, length: italicMatch[0].length });
+    if (boldUMatch) matches.push({ type: "bold", match: boldUMatch, length: boldUMatch[0].length });
+    if (italicUMatch) matches.push({ type: "italic", match: italicUMatch, length: italicUMatch[0].length });
+    if (strikeMatch) matches.push({ type: "strike", match: strikeMatch, length: strikeMatch[0].length });
+    if (codeMatch) matches.push({ type: "code", match: codeMatch, length: codeMatch[0].length });
+    if (imageMatch) matches.push({ type: "image", match: imageMatch, length: imageMatch[0].length });
+    if (linkMatch) matches.push({ type: "link", match: linkMatch, length: linkMatch[0].length });
+
+    // Sort by match length descending (longer patterns first, e.g., *** before ** before *)
+    matches.sort((a, b) => b.length - a.length);
+
+    if (matches.length > 0) {
+      const earliest = matches[0];
+      const match = earliest.match;
+
+      // If match doesn't start at position 0, add plain text prefix
+      if (match.index! > 0) {
+        nodes.push({ type: "text", text: remaining.slice(0, match.index) });
+      }
+
+      switch (earliest.type) {
+        case "boldItalic": {
+          const inner = parseInlineMarkdown(match[1]!);
+          for (const n of inner) {
+            nodes.push({
+              ...n,
+              marks: [...(n.marks || []), { type: "bold" }, { type: "italic" }],
+            });
+          }
+          break;
+        }
+        case "bold": {
+          const inner = parseInlineMarkdown(match[1]!);
+          for (const n of inner) {
+            nodes.push({ ...n, marks: [...(n.marks || []), { type: "bold" }] });
+          }
+          break;
+        }
+        case "italic":
+          nodes.push({ type: "text", text: match[1]!, marks: [{ type: "italic" }] });
+          break;
+        case "strike":
+          nodes.push({ type: "text", text: match[1]!, marks: [{ type: "strike" }] });
+          break;
+        case "code":
+          nodes.push({ type: "text", text: match[1]!, marks: [{ type: "code" }] });
+          break;
+        case "image":
+          nodes.push({
+            type: "text",
+            text: match[1] || "",
+            marks: [{ type: "link", attrs: { href: match[2]!, title: match[3] || null } }],
+          });
+          break;
+        case "link":
+          nodes.push({ type: "text", text: match[1]!, marks: [{ type: "link", attrs: { href: match[2]! } }] });
+          break;
+      }
+
+      remaining = remaining.slice(match.index! + match[0].length);
+    } else {
+      // No match found, consume one character
+      nodes.push({ type: "text", text: remaining[0]! });
+      remaining = remaining.slice(1);
+    }
+  }
+
+  return nodes;
+};
+
+const isListItem = (line: string): false | "bullet" | "ordered" => {
+  if (/^\s*[-*+]\s+/.test(line)) return "bullet";
+  if (/^\s*\d+\.\s+/.test(line)) return "ordered";
+  return false;
+};
+
+const stripListItemMarker = (line: string): string => {
+  return line.replace(/^\s*(?:[-*+]|\d+\.)\s+/, "");
+};
+
+const isBlockquoteLine = (line: string): boolean => /^\s*>\s?/.test(line);
+
+const stripBlockquoteMarker = (line: string): string => line.replace(/^\s*>\s?/, "");
 
 export const markdownToDoc = (markdown: string): TiptapDoc => {
   const lines = markdown.replace(/\r\n/g, "\n").split("\n");
@@ -54,6 +171,51 @@ export const markdownToDoc = (markdown: string): TiptapDoc => {
       continue;
     }
 
+    // Blockquote: collect consecutive > lines
+    if (isBlockquoteLine(lines[index])) {
+      const quoteLines: string[] = [];
+      while (index < lines.length && isBlockquoteLine(lines[index])) {
+        quoteLines.push(stripBlockquoteMarker(lines[index]));
+        index += 1;
+      }
+      const quoteText = quoteLines.join("\n").trim();
+      content.push({
+        type: "blockquote",
+        content: [{ type: "paragraph", content: parseInlineMarkdown(quoteText) }],
+      });
+      continue;
+    }
+
+    // Unordered list: collect consecutive bullet items
+    if (isListItem(lines[index]) === "bullet") {
+      const listItems: TiptapNode[] = [];
+      while (index < lines.length && isListItem(lines[index]) === "bullet") {
+        const itemText = stripListItemMarker(lines[index]);
+        listItems.push({
+          type: "listItem",
+          content: [{ type: "paragraph", content: parseInlineMarkdown(itemText) }],
+        });
+        index += 1;
+      }
+      content.push({ type: "bulletList", content: listItems });
+      continue;
+    }
+
+    // Ordered list: collect consecutive ordered items
+    if (isListItem(lines[index]) === "ordered") {
+      const listItems: TiptapNode[] = [];
+      while (index < lines.length && isListItem(lines[index]) === "ordered") {
+        const itemText = stripListItemMarker(lines[index]);
+        listItems.push({
+          type: "listItem",
+          content: [{ type: "paragraph", content: parseInlineMarkdown(itemText) }],
+        });
+        index += 1;
+      }
+      content.push({ type: "orderedList", content: listItems });
+      continue;
+    }
+
     const blockLines: string[] = [];
     while (index < lines.length && lines[index].trim()) {
       blockLines.push(lines[index]);
@@ -68,7 +230,7 @@ export const markdownToDoc = (markdown: string): TiptapDoc => {
       content.push({
         type: "heading",
         attrs: { level: heading[1].length },
-        content: [{ type: "text", text: heading[2] }],
+        content: parseInlineMarkdown(heading[2]!),
       });
       continue;
     }
@@ -92,7 +254,7 @@ export const markdownToDoc = (markdown: string): TiptapDoc => {
 
     content.push({
       type: "paragraph",
-      content: [{ type: "text", text: block }],
+      content: parseInlineMarkdown(block),
     });
   }
 
@@ -259,12 +421,35 @@ const inlineToMarkdown = (content: unknown): string => {
       const current = node as {
         type?: unknown;
         text?: unknown;
+        marks?: Array<{ type: string; attrs?: Record<string, unknown> }>;
         attrs?: Record<string, unknown>;
         content?: unknown;
       };
 
       if (typeof current.text === "string") {
-        return current.text;
+        const marks = current.marks;
+        let text = current.text;
+
+        if (marks && marks.length > 0) {
+          // Apply marks in reverse order (outermost first)
+          for (let i = marks.length - 1; i >= 0; i--) {
+            const mark = marks[i];
+            if (mark.type === "bold") {
+              text = `**${text}**`;
+            } else if (mark.type === "italic") {
+              text = `*${text}*`;
+            } else if (mark.type === "code") {
+              text = `\`${text}\``;
+            } else if (mark.type === "strike") {
+              text = `~~${text}~~`;
+            } else if (mark.type === "link") {
+              const href = typeof mark.attrs?.href === "string" ? mark.attrs.href : "";
+              text = `[${text}](${href})`;
+            }
+          }
+        }
+
+        return text;
       }
 
       if (current.type === "hardBreak") {


### PR DESCRIPTION
## Description

The `markdownToDoc` function in `packages/shared/src/content.ts` only parsed block-level Markdown structures (headings, code blocks, images, paragraphs) but treated inline formatting like `**bold**`, `*italic*`, `` `code` ``, `~~strikethrough~~`, and `[links](url)` as literal text.

This meant notes created via MCP or any Markdown-to-TipTap conversion path would show raw Markdown syntax instead of rendered formatting in the rich text editor.

## Changes

- Added `TiptapMark` type for bold, italic, code, strike, and link marks
- Updated `TiptapTextNode` to support optional `marks` array
- Rewrote `parseInlineMarkdown()` with a step-by-step tokenizer that handles all major inline Markdown syntax
- Updated `inlineToMarkdown()` to preserve marks when converting TipTap back to Markdown
- Added support for nested formatting (e.g., `***bold italic***`)
- Added support for lists (`- `, `1. `) and blockquotes (`> `)

## Testing

Verified via MCP that created notes now properly render inline formatting:
- `**bold**` → text with bold mark ✅
- `*italic*` → text with italic mark ✅
- `` `code` `` → text with code mark ✅
- `~~strike~~` → text with strike mark ✅
- `[link](url)` → text with link mark ✅
- Lists and blockquotes also supported ✅