### PR TITLE
feat: add sidebar collapse/expand toggle for notebook tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ coverage/
 wrangler.local.toml
 
 *.log
+
+# Local MCP token
+.mcp-token.json

--- a/apps/web/src/components/WorkspaceApp.tsx
+++ b/apps/web/src/components/WorkspaceApp.tsx
@@ -2374,7 +2374,7 @@ export const WorkspaceApp = ({
       <div className="min-w-0 flex-1">
         <main
           className={cn(
-            "grid h-[100dvh] min-h-0 grid-cols-[minmax(0,1fr)]",
+            "relative grid h-[100dvh] min-h-0 grid-cols-[minmax(0,1fr)]",
             rightView === "editor"
               ? sidebarCollapsed
                 ? "lg:grid-cols-[0px_var(--memo-list-width)_minmax(0,1fr)]"
@@ -2387,24 +2387,11 @@ export const WorkspaceApp = ({
         >
           <aside
             className={cn(
-              "relative min-h-0 border-r border-slate-200 bg-white/75 backdrop-blur-lg transition-all duration-200 lg:block",
+              "min-h-0 border-r border-slate-200 bg-white/75 backdrop-blur-lg transition-all duration-200 lg:block",
               visibleActivePane === "notebooks" ? "block" : "hidden",
               sidebarCollapsed && "lg:w-0 lg:overflow-hidden lg:border-r-0"
             )}
           >
-            <button
-              className={cn(
-                "absolute right-[-12px] top-4 z-30 hidden h-6 w-6 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-500 shadow-sm transition-all hover:bg-slate-100 hover:text-slate-700 lg:flex",
-                sidebarCollapsed && "right-[-12px]"
-              )}
-              type="button"
-              title={sidebarCollapsed ? t("notebookPane.expand") || "展开侧栏" : t("notebookPane.collapse") || "折叠侧栏"}
-              aria-label={sidebarCollapsed ? t("notebookPane.expand") || "展开侧栏" : t("notebookPane.collapse") || "折叠侧栏"}
-              onClick={() => setSidebarCollapsed((prev) => !prev)}
-            >
-              <PanelLeftClose className={cn("h-3.5 w-3.5", sidebarCollapsed && "hidden")} />
-              <PanelLeftOpen className={cn("h-3.5 w-3.5", !sidebarCollapsed && "hidden")} />
-            </button>
             {(isDesktop || visibleActivePane === "notebooks") && (
               <Suspense fallback={<PaneLoadingFallback label={t("workspace.loading.notebooks")} />}>
                 <NotebookPane
@@ -2454,6 +2441,20 @@ export const WorkspaceApp = ({
               </Suspense>
             )}
           </aside>
+
+          <button
+            className={cn(
+              "absolute left-[258px] top-4 z-30 hidden h-6 w-6 -translate-x-1/2 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-500 shadow-sm transition-all hover:bg-slate-100 hover:text-slate-700 lg:flex",
+              sidebarCollapsed && "left-[4px]"
+            )}
+            type="button"
+            title={sidebarCollapsed ? "展开侧栏" : "折叠侧栏"}
+            aria-label={sidebarCollapsed ? "展开侧栏" : "折叠侧栏"}
+            onClick={() => setSidebarCollapsed((prev) => !prev)}
+          >
+            <PanelLeftClose className={cn("h-3.5 w-3.5", sidebarCollapsed && "hidden")} />
+            <PanelLeftOpen className={cn("h-3.5 w-3.5", !sidebarCollapsed && "hidden")} />
+          </button>
 
           <section
             className={cn(

--- a/apps/web/src/components/WorkspaceApp.tsx
+++ b/apps/web/src/components/WorkspaceApp.tsx
@@ -13,7 +13,7 @@ import {
   type PointerEvent as ReactPointerEvent,
 } from "react";
 import { useInfiniteQuery, useQuery, useMutation, useQueryClient, type QueryClient } from "@tanstack/react-query";
-import { Home, Search, UserRound, Plus, ChevronDown, ChevronRight, RefreshCw, X } from "lucide-react";
+import { Home, Search, UserRound, Plus, ChevronDown, ChevronRight, ChevronLeft, RefreshCw, X, PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router";
 import { Button } from "@/components/ui/button";
@@ -803,6 +803,7 @@ export const WorkspaceApp = ({
   const isPullRefreshingRef = useRef(false);
   const skipNextHomeRouteSyncRef = useRef(false);
 
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [mobileListActionsOpen, setMobileListActionsOpen] = useState(false);
   const [mobileMoveOpen, setMobileMoveOpen] = useState(false);
   const [mobileMoreOpen, setMobileMoreOpen] = useState(false);
@@ -2375,17 +2376,35 @@ export const WorkspaceApp = ({
           className={cn(
             "grid h-[100dvh] min-h-0 grid-cols-[minmax(0,1fr)]",
             rightView === "editor"
-              ? "lg:grid-cols-[260px_var(--memo-list-width)_minmax(0,1fr)]"
-              : "lg:grid-cols-[260px_1fr]"
+              ? sidebarCollapsed
+                ? "lg:grid-cols-[0px_var(--memo-list-width)_minmax(0,1fr)]"
+                : "lg:grid-cols-[260px_var(--memo-list-width)_minmax(0,1fr)]"
+              : sidebarCollapsed
+                ? "lg:grid-cols-[0px_1fr]"
+                : "lg:grid-cols-[260px_1fr]"
           )}
           style={{ "--memo-list-width": `${memoListWidth}px` } as CSSProperties}
         >
           <aside
             className={cn(
-              "min-h-0 border-r border-slate-200 bg-white/75 backdrop-blur-lg lg:block",
-              visibleActivePane === "notebooks" ? "block" : "hidden"
+              "relative min-h-0 border-r border-slate-200 bg-white/75 backdrop-blur-lg transition-all duration-200 lg:block",
+              visibleActivePane === "notebooks" ? "block" : "hidden",
+              sidebarCollapsed && "lg:w-0 lg:overflow-hidden lg:border-r-0"
             )}
           >
+            <button
+              className={cn(
+                "absolute right-[-12px] top-4 z-30 hidden h-6 w-6 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-500 shadow-sm transition-all hover:bg-slate-100 hover:text-slate-700 lg:flex",
+                sidebarCollapsed && "right-[-12px]"
+              )}
+              type="button"
+              title={sidebarCollapsed ? t("notebookPane.expand") || "展开侧栏" : t("notebookPane.collapse") || "折叠侧栏"}
+              aria-label={sidebarCollapsed ? t("notebookPane.expand") || "展开侧栏" : t("notebookPane.collapse") || "折叠侧栏"}
+              onClick={() => setSidebarCollapsed((prev) => !prev)}
+            >
+              <PanelLeftClose className={cn("h-3.5 w-3.5", sidebarCollapsed && "hidden")} />
+              <PanelLeftOpen className={cn("h-3.5 w-3.5", !sidebarCollapsed && "hidden")} />
+            </button>
             {(isDesktop || visibleActivePane === "notebooks") && (
               <Suspense fallback={<PaneLoadingFallback label={t("workspace.loading.notebooks")} />}>
                 <NotebookPane


### PR DESCRIPTION
## Description

Adds a toggle button to collapse/expand the leftmost notebook sidebar (NotebookPane), giving users more horizontal space for the memo list and editor.

## Changes

- Added `sidebarCollapsed` state in `WorkspaceApp.tsx`
- Added a toggle button (`PanelLeftClose`/`PanelLeftOpen` icon) positioned at the sidebar edge
- When collapsed, the sidebar width reduces to 0px and the grid reflows automatically
- The toggle button remains visible even when the sidebar is collapsed (positioned outside the sidebar container)
- Added `.mcp-token.json` to `.gitignore`

## Usage

Click the `<` button on the right edge of the sidebar to collapse it; click `>` (now at the left edge of the window) to expand it back.