### PR TITLE
feat: add editor fullscreen mode with F10 shortcut

### DIFF
--- a/apps/web/src/components/EditorPane.tsx
+++ b/apps/web/src/components/EditorPane.tsx
@@ -1108,6 +1108,7 @@ const RichEditorPane = ({
   const [noteSearchReplaceOpen, setNoteSearchReplaceOpen] = useState(false);
   const [noteSearchReplacement, setNoteSearchReplacement] = useState("");
   const [noteSearchIndex, setNoteSearchIndex] = useState(0);
+  const [editorFullscreen, setEditorFullscreen] = useState(false);
   const [isMobileViewport, setIsMobileViewport] = useState(() =>
     typeof window === "undefined" ? false : window.matchMedia(MOBILE_EDITOR_QUERY).matches
   );
@@ -2267,7 +2268,14 @@ const RichEditorPane = ({
   };
 
   return (
-    <div className="relative flex h-full min-w-0 flex-col bg-white">
+    <div
+      className={cn(
+        "relative flex min-w-0 flex-col bg-white transition-all duration-200",
+        editorFullscreen
+          ? "fixed inset-0 z-50 h-[100dvh]"
+          : "h-full"
+      )}
+    >
       {selectionActionBar}
       <header className="shrink-0 border-b border-slate-200 bg-white">
         <div className="flex min-h-12 items-center justify-between gap-2 border-b border-slate-100 px-3 py-2 sm:px-5">
@@ -2396,6 +2404,15 @@ const RichEditorPane = ({
               <History className="h-5 w-5" strokeWidth={2.25} />
             </Button>
             <GitHubRepositoryLink className="hidden h-8 w-8 justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/70 lg:inline-flex" iconClassName="h-5 w-5" />
+            <button
+              className="flex h-8 w-8 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/70"
+              type="button"
+              title={editorFullscreen ? "退出全屏" : "全屏编辑"}
+              aria-label={editorFullscreen ? "退出全屏" : "全屏编辑"}
+              onClick={() => setEditorFullscreen((prev) => !prev)}
+            >
+              {editorFullscreen ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
+            </button>
             <ThemeToggle />
             {!readOnly && (
               <Button

--- a/apps/web/src/components/EditorPane.tsx
+++ b/apps/web/src/components/EditorPane.tsx
@@ -1108,6 +1108,7 @@ const RichEditorPane = ({
   const [noteSearchReplaceOpen, setNoteSearchReplaceOpen] = useState(false);
   const [noteSearchReplacement, setNoteSearchReplacement] = useState("");
   const [noteSearchIndex, setNoteSearchIndex] = useState(0);
+  const [editorFullscreen, setEditorFullscreen] = useState(false);
   const [isMobileViewport, setIsMobileViewport] = useState(() =>
     typeof window === "undefined" ? false : window.matchMedia(MOBILE_EDITOR_QUERY).matches
   );
@@ -1492,6 +1493,19 @@ const RichEditorPane = ({
       editor.off("transaction", refreshToolbar);
     };
   }, [editor]);
+
+  // F10 切换全屏编辑
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "F10") {
+        event.preventDefault();
+        setEditorFullscreen((prev) => !prev);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
 
   const getMobilePlainTextValue = useCallback(
     () => (mobileTextAreaRef.current ? getMobilePlainTextElementValue(mobileTextAreaRef.current) : mobilePlainText),
@@ -2267,7 +2281,14 @@ const RichEditorPane = ({
   };
 
   return (
-    <div className="relative flex h-full min-w-0 flex-col bg-white">
+    <div
+      className={cn(
+        "relative flex min-w-0 flex-col bg-white transition-all duration-200",
+        editorFullscreen
+          ? "fixed inset-0 z-50 h-[100dvh]"
+          : "h-full"
+      )}
+    >
       {selectionActionBar}
       <header className="shrink-0 border-b border-slate-200 bg-white">
         <div className="flex min-h-12 items-center justify-between gap-2 border-b border-slate-100 px-3 py-2 sm:px-5">
@@ -2395,6 +2416,19 @@ const RichEditorPane = ({
             <Button className="hidden h-8 w-8 text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-950 focus-visible:ring-2 focus-visible:ring-slate-300 sm:inline-flex" size="icon" variant="ghost" title="版本历史" aria-label="版本历史" onClick={() => setHistoryOpen(true)}>
               <History className="h-5 w-5" strokeWidth={2.25} />
             </Button>
+            <button
+              className="flex h-8 w-8 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/70"
+              type="button"
+              title={editorFullscreen ? "退出全屏" : "全屏编辑"}
+              aria-label={editorFullscreen ? "退出全屏" : "全屏编辑"}
+              onClick={() => setEditorFullscreen((prev) => !prev)}
+            >
+              {editorFullscreen ? (
+                <ChevronRight className="h-4 w-4" />
+              ) : (
+                <ChevronLeft className="h-4 w-4" />
+              )}
+            </button>
             <GitHubRepositoryLink className="hidden h-8 w-8 justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/70 lg:inline-flex" iconClassName="h-5 w-5" />
             <ThemeToggle />
             {!readOnly && (

--- a/apps/web/src/components/EditorPane.tsx
+++ b/apps/web/src/components/EditorPane.tsx
@@ -1108,7 +1108,6 @@ const RichEditorPane = ({
   const [noteSearchReplaceOpen, setNoteSearchReplaceOpen] = useState(false);
   const [noteSearchReplacement, setNoteSearchReplacement] = useState("");
   const [noteSearchIndex, setNoteSearchIndex] = useState(0);
-  const [editorFullscreen, setEditorFullscreen] = useState(false);
   const [isMobileViewport, setIsMobileViewport] = useState(() =>
     typeof window === "undefined" ? false : window.matchMedia(MOBILE_EDITOR_QUERY).matches
   );
@@ -2268,14 +2267,7 @@ const RichEditorPane = ({
   };
 
   return (
-    <div
-      className={cn(
-        "relative flex min-w-0 flex-col bg-white transition-all duration-200",
-        editorFullscreen
-          ? "fixed inset-0 z-50 h-[100dvh]"
-          : "h-full"
-      )}
-    >
+    <div className="relative flex h-full min-w-0 flex-col bg-white">
       {selectionActionBar}
       <header className="shrink-0 border-b border-slate-200 bg-white">
         <div className="flex min-h-12 items-center justify-between gap-2 border-b border-slate-100 px-3 py-2 sm:px-5">
@@ -2404,15 +2396,6 @@ const RichEditorPane = ({
               <History className="h-5 w-5" strokeWidth={2.25} />
             </Button>
             <GitHubRepositoryLink className="hidden h-8 w-8 justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/70 lg:inline-flex" iconClassName="h-5 w-5" />
-            <button
-              className="flex h-8 w-8 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/70"
-              type="button"
-              title={editorFullscreen ? "退出全屏" : "全屏编辑"}
-              aria-label={editorFullscreen ? "退出全屏" : "全屏编辑"}
-              onClick={() => setEditorFullscreen((prev) => !prev)}
-            >
-              {editorFullscreen ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
-            </button>
             <ThemeToggle />
             {!readOnly && (
               <Button

--- a/apps/web/src/components/settings/ShortcutSettingsItem.tsx
+++ b/apps/web/src/components/settings/ShortcutSettingsItem.tsx
@@ -162,6 +162,23 @@ export const ShortcutSettingsItem = ({ shortcutSettings, onShortcutSettingsChang
             })}
           </div>
 
+          <div className="rounded-lg border border-slate-200 bg-slate-50/60 p-3">
+            <div className="min-w-0">
+              <div className="text-sm font-semibold text-slate-900">
+                {t("shortcuts.actions.toggleFullscreen.label") || "全屏编辑"}
+              </div>
+              <div className="mt-0.5 text-xs leading-4 text-slate-500">
+                {t("shortcuts.actions.toggleFullscreen.description") || "切换编辑器全屏模式。"}
+              </div>
+            </div>
+            <div className="mt-2 flex items-center gap-2">
+              <kbd className="inline-flex h-7 min-w-[2rem] items-center justify-center rounded-md border border-slate-300 bg-white px-2 font-mono text-xs font-semibold text-slate-700 shadow-sm">
+                F10
+              </kbd>
+              <span className="text-xs text-slate-400">{t("shortcuts.fixed") || "固定快捷键"}</span>
+            </div>
+          </div>
+
           {captureMessage ? (
             <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-medium text-amber-700">
               {captureMessage}

--- a/apps/web/src/i18n/resources/en-US.ts
+++ b/apps/web/src/i18n/resources/en-US.ts
@@ -200,6 +200,7 @@ export const enUS = {
     reset: "Restore defaults",
     requireModifier: "Press a shortcut that includes Ctrl, ⌘, or Alt.",
     conflict: "This shortcut is already used by “{{label}}”.",
+    fixed: "Fixed shortcut",
     actions: {
       createMemo: {
         label: "New note",
@@ -216,6 +217,10 @@ export const enUS = {
       focusReplace: {
         label: "Replace text",
         description: "Open replace in the current note.",
+      },
+      toggleFullscreen: {
+        label: "Toggle fullscreen",
+        description: "Toggle editor fullscreen mode.",
       },
     },
   },

--- a/apps/web/src/i18n/resources/zh-CN.ts
+++ b/apps/web/src/i18n/resources/zh-CN.ts
@@ -200,6 +200,7 @@ export const zhCN = {
     reset: "恢复默认",
     requireModifier: "请按下包含 Ctrl、⌘ 或 Alt 的组合键。",
     conflict: "这个组合键已用于「{{label}}」。",
+    fixed: "固定快捷键",
     actions: {
       createMemo: {
         label: "新建笔记",
@@ -216,6 +217,10 @@ export const zhCN = {
       focusReplace: {
         label: "替换文本",
         description: "在当前笔记中打开替换。",
+      },
+      toggleFullscreen: {
+        label: "全屏编辑",
+        description: "切换编辑器全屏模式。",
       },
     },
   },


### PR DESCRIPTION
## Description

Adds a fullscreen mode for the editor pane, allowing users to focus entirely on writing and reading notes without distractions from the sidebar or memo list.

## Features

1. **Fullscreen toggle button** - A button in the editor toolbar (between GitHub link and ThemeToggle) to toggle fullscreen mode
2. **F10 keyboard shortcut** - Press F10 to quickly toggle fullscreen without using the mouse
3. **Settings display** - The F10 shortcut is shown (read-only) in the keyboard shortcuts settings dialog

## Changes

- `EditorPane.tsx`: Added `editorFullscreen` state; when active the editor takes `fixed inset-0 z-50 h-[100dvh]` for true fullscreen overlay
- `EditorPane.tsx`: Added F10 keydown listener to toggle fullscreen
- `ShortcutSettingsItem.tsx`: Added read-only F10 shortcut display in the shortcuts dialog
- i18n: Added `toggleFullscreen` and `fixed` translation keys in both zh-CN and en-US

## Implementation Notes

- Uses `ChevronLeft`/`ChevronRight` icons (already available in the project) instead of `Maximize2`/`Minimize2` which had TypeScript resolution issues
- Fullscreen is implemented with CSS (`fixed` positioning) rather than the Fullscreen API, giving smoother transitions and better compatibility