### PR TITLE
add copy button to code blocks in the web editor

### DIFF
--- a/apps/web/src/components/MermaidCodeBlock.tsx
+++ b/apps/web/src/components/MermaidCodeBlock.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { NodeViewContent, NodeViewWrapper, type NodeViewProps } from "@tiptap/react";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "./ThemeProvider";
@@ -36,6 +36,30 @@ export const MermaidCodeBlock = ({ editor, node }: NodeViewProps) => {
   const [svg, setSvg] = useState("");
   const [sourceVisible, setSourceVisible] = useState(false);
   const [renderState, setRenderState] = useState<"idle" | "loading" | "ready" | "error">("idle");
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    const text = node.textContent;
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const textarea = document.createElement("textarea");
+        textarea.value = text;
+        textarea.setAttribute("readonly", "");
+        textarea.style.position = "fixed";
+        textarea.style.left = "-9999px";
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand("copy");
+        document.body.removeChild(textarea);
+      }
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1600);
+    } catch {
+      // Clipboard API may be unavailable.
+    }
+  }, [node]);
 
   useEffect(() => {
     if (!isMermaid || !source) {
@@ -124,6 +148,19 @@ export const MermaidCodeBlock = ({ editor, node }: NodeViewProps) => {
         : "edgeever-code-block"}
       data-language={language}
     >
+      <button
+        type="button"
+        className="edgeever-code-copy-button"
+        contentEditable={false}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          void handleCopy();
+        }}
+        aria-label={copied ? t("common.copied") : t("common.copy")}
+      >
+        {copied ? t("common.copied") : t("common.copy")}
+      </button>
       {isMermaid && (
         <div
           className="edgeever-mermaid-preview"

--- a/apps/web/src/styles/editor-themes/base.css
+++ b/apps/web/src/styles/editor-themes/base.css
@@ -53,9 +53,21 @@
 .edgeever-editor[data-editor-theme]:not([data-editor-theme="default"]) .ProseMirror code,
 .edgeever-editor[data-editor-theme]:not([data-editor-theme="default"]) .ProseMirror pre,
 .edgeever-editor[data-editor-theme]:not([data-editor-theme="default"]) .ProseMirror .edgeever-code-source {
-
   border-color: var(--editor-theme-border);
   background: var(--editor-theme-soft);
+  color: var(--editor-theme-text);
+}
+
+.edgeever-editor[data-editor-theme]:not([data-editor-theme="default"]) .ProseMirror .edgeever-code-block .edgeever-code-copy-button,
+.edgeever-editor[data-editor-theme]:not([data-editor-theme="default"]) .ProseMirror .edgeever-mermaid-code-block .edgeever-code-copy-button {
+  border-color: var(--editor-theme-border);
+  background: var(--editor-theme-soft);
+  color: var(--editor-theme-muted);
+}
+
+.edgeever-editor[data-editor-theme]:not([data-editor-theme="default"]) .ProseMirror .edgeever-code-block .edgeever-code-copy-button:hover,
+.edgeever-editor[data-editor-theme]:not([data-editor-theme="default"]) .ProseMirror .edgeever-mermaid-code-block .edgeever-code-copy-button:hover {
+  background: color-mix(in srgb, var(--editor-theme-soft) 80%, var(--editor-theme-accent));
   color: var(--editor-theme-text);
 }
 

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -326,7 +326,45 @@ textarea {
 
 .ProseMirror .edgeever-code-block,
 .ProseMirror .edgeever-mermaid-code-block {
+  position: relative;
   margin: 0 0 1rem;
+}
+
+.ProseMirror .edgeever-code-block .edgeever-code-copy-button,
+.ProseMirror .edgeever-mermaid-code-block .edgeever-code-copy-button {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+  border: 1px solid #d9eadf;
+  border-radius: 6px;
+  background: #f7fbf8;
+  padding: 3px 8px;
+  color: #475569;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.7em;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 120ms ease;
+  pointer-events: none;
+}
+
+.ProseMirror .edgeever-code-block:hover .edgeever-code-copy-button,
+.ProseMirror .edgeever-mermaid-code-block:hover .edgeever-code-copy-button {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.ProseMirror .edgeever-code-block .edgeever-code-copy-button:hover,
+.ProseMirror .edgeever-mermaid-code-block .edgeever-code-copy-button:hover {
+  background: #eef4f0;
+  color: #1e293b;
 }
 
 .ProseMirror .edgeever-code-source {
@@ -932,6 +970,19 @@ textarea {
   border-color: #166534;
   background: #13261a;
   color: #cbd5e1;
+}
+
+:root.dark .ProseMirror .edgeever-code-block .edgeever-code-copy-button,
+:root.dark .ProseMirror .edgeever-mermaid-code-block .edgeever-code-copy-button {
+  border-color: #166534;
+  background: #13261a;
+  color: #a7f3d0;
+}
+
+:root.dark .ProseMirror .edgeever-code-block .edgeever-code-copy-button:hover,
+:root.dark .ProseMirror .edgeever-mermaid-code-block .edgeever-code-copy-button:hover {
+  background: #1a3a24;
+  color: #ecfdf5;
 }
 
 :root.dark .ProseMirror .edgeever-mermaid-preview {

--- a/packages/shared/src/i18n/en-US.ts
+++ b/packages/shared/src/i18n/en-US.ts
@@ -12,6 +12,7 @@ export const enUS = {
     untitledMemo: "Untitled note",
     processing: "Processing",
     saving: "Saving",
+    copy: "Copy",
     copied: "Copied",
     githubRepository: "GitHub repository",
   },

--- a/packages/shared/src/i18n/zh-CN.ts
+++ b/packages/shared/src/i18n/zh-CN.ts
@@ -12,6 +12,7 @@ export const zhCN = {
     untitledMemo: "无标题笔记",
     processing: "处理中",
     saving: "保存中",
+    copy: "复制",
     copied: "已复制",
     githubRepository: "GitHub 仓库",
   },


### PR DESCRIPTION
Fixes #93 

Adds a copy button to all code blocks in the web editor (both regular and Mermaid).

- Hover-reveal "Copy" / "Copied" button positioned at the top-right corner of each code block
- Uses the Clipboard API with an `execCommand` fallback for older browsers
- Themed for light mode, dark mode, and non-default editor themes
- i18n supported (en-US, zh-CN)
- Mobile code blocks are unaffected (DOM-based node view, out of scope)