### PR TITLE
fix(deploy): keep wrangler wrapper diagnostics off stdout

### DIFF
--- a/scripts/run-wrangler.mjs
+++ b/scripts/run-wrangler.mjs
@@ -25,6 +25,14 @@ if (wranglerArgs.length === 0) {
 
 const requestedInstance = process.env.EDGE_EVER_INSTANCE;
 
+// Levelled wrapper diagnostics. Every level goes to stderr because stdout is
+// reserved for Wrangler's own output: callers such as
+// scripts/verify-deployment.mjs parse that stdout as the --json payload, and a
+// progress line there makes JSON.parse fail on "[info]"/"[ok]".
+const notice = (level, message) => {
+  process.stderr.write(`[${level}] ${message}\n`);
+};
+
 const loadLocalEnv = () => {
   const envPath = resolve(".env.local");
   if (!existsSync(envPath)) {
@@ -120,7 +128,7 @@ if (migrationCommand) {
     );
   }
   changed = true;
-  console.log(`[ok] local D1 migrations: ${migrationFiles.length} files`);
+  notice("ok", `local D1 migrations: ${migrationFiles.length} files`);
 }
 
 const replaceTomlValue = (source, key, value) => {
@@ -185,7 +193,7 @@ config = replaceTomlValue(config, "database_name", envValue("D1_DATABASE_NAME"))
 if (isRemoteCommand && config.includes(`database_id = "${PLACEHOLDER_D1_ID}"`)) {
   const databaseName = config.match(/^database_name\s*=\s*"([^"]+)"/m)?.[1];
   if (databaseName) {
-    console.log(`[info] resolving Cloudflare D1 database id for ${databaseName}`);
+    notice("info", `resolving Cloudflare D1 database id for ${databaseName}`);
     const listResult = runWranglerSync(
       ["--config", baseConfigPath, "d1", "list", "--json"],
       {
@@ -200,7 +208,7 @@ if (isRemoteCommand && config.includes(`database_id = "${PLACEHOLDER_D1_ID}"`)) 
         const discoveredId = findD1DatabaseIdByName(listResult.stdout, databaseName);
         if (discoveredId && UUID_PATTERN.test(discoveredId)) {
           config = replaceTomlValue(config, "database_id", discoveredId);
-          console.log(`[ok] resolved D1 database ${databaseName}`);
+          notice("ok", `resolved D1 database ${databaseName}`);
         }
       } catch (error) {
         console.error(error instanceof Error ? error.message : String(error));
@@ -336,7 +344,7 @@ if (isDeployCommand && Object.keys(authSecrets).length === 0 && !useExistingAuth
 }
 
 if (isDeployCommand && Object.keys(authSecrets).length === 0 && useExistingAuthSecret) {
-  console.log("[info] using the authentication Secret provisioned by Cloudflare");
+  notice("info", "using the authentication Secret provisioned by Cloudflare");
 }
 
 if (isLocalDevCommand && !hasEnvFileArg) {

--- a/tests/deployment-verify.test.ts
+++ b/tests/deployment-verify.test.ts
@@ -29,6 +29,12 @@ describe("deployment verification", () => {
     expect(parseD1Rows("")).toEqual([]);
   });
 
+  test("reports unexpected Wrangler output as a parse failure", () => {
+    expect(() => parseJsonOutput("Authentication error [code: 10000]", "Worker Secrets")).toThrow(
+      "Wrangler returned invalid JSON while checking Worker Secrets",
+    );
+  });
+
   test("parses current and wrapped Wrangler secret output", () => {
     expect(parseSecretNames(JSON.stringify([{ name: "EDGE_EVER_AUTH_PASSWORD" }]))).toContain(
       "EDGE_EVER_AUTH_PASSWORD",


### PR DESCRIPTION
scripts/run-wrangler.mjs printed its own progress notices with console.log while running Wrangler with stdio: "inherit", so both shared one stdout. When database_id is still the placeholder, every --remote command first prints "[info] resolving Cloudflare D1 database id for edgeever", which scripts/verify-deployment.mjs then captured as the --json payload:

  [fail] Wrangler returned invalid JSON while checking the remote D1
  schema: JSON Parse error: Unexpected identifier "info"

This broke deploy:verify on Cloudflare Builds, where no EDGE_EVER_D1_DATABASE_ID is set and the name-resolution fallback always runs.

Route the wrapper's levelled diagnostics through a notice() helper that writes to stderr, leaving stdout reserved for Wrangler's output. Levels and message text are unchanged, and both streams still appear in build logs. This also fixes the same latent crash in scripts/reset-password.mjs, whose parseD1Rows calls JSON.parse on the wrapper's stdout directly.