### PR TITLE
fix(web): guard `window` access in the shared API request path

### DIFF
--- a/apps/web/src/lib/api.test.mjs
+++ b/apps/web/src/lib/api.test.mjs
@@ -8,6 +8,7 @@ let secureSessionToken = "";
 let failSecureSessionWrite = false;
 
 globalThis.window = {
+  location: { hostname: "notes.example.com", origin: "https://notes.example.com" },
   edgeeverDesktop: {
     isAvailable: true,
     apiBaseUrl: "",

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -243,7 +243,7 @@ const isDesktopAuthenticationRequest = (path: string) =>
 
 const request = async <T>(path: string, init?: RequestInit): Promise<T> => {
   const headers = new Headers(init?.headers);
-  const isDesktop = Boolean(window.edgeeverDesktop?.isAvailable);
+  const isDesktop = Boolean(typeof window !== "undefined" && window.edgeeverDesktop?.isAvailable);
   const sessionToken = isDesktop ? getDesktopSessionToken() : undefined;
 
   if (isDesktop && desktopSessionRejected && !isDesktopAuthenticationRequest(path)) {

--- a/apps/web/src/lib/desktop-resources.test.mjs
+++ b/apps/web/src/lib/desktop-resources.test.mjs
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 globalThis.window = {
+  location: { hostname: "notes.example.com", origin: "https://notes.example.com" },
   edgeeverDesktop: { isAvailable: true, apiBaseUrl: "https://notes.example.com" },
 };
 


### PR DESCRIPTION
## 问题

在干净检出的仓库上直接跑 `bun test`，有 3 个用例稳定失败（`tests/web-sync-queue.test.ts`）：

```
(fail) web sync queue concurrency > coalesces simultaneous sync runs so one queued save is sent only once
(fail) web sync queue concurrency > does not delete a newer draft queued while an older request is in flight  ← 超时 5000ms
(fail) web sync queue concurrency > keeps a genuine server revision mismatch as a conflict
```

我在 v1.6.48 / v1.6.54 / v1.7.1 / v1.8.4 以及当前 `main` 上都复现了，失败用例完全相同。

## 根因

`apps/web/src/lib/api.ts` 的 `request()` 里：

```ts
const isDesktop = Boolean(window.edgeeverDesktop?.isAvailable);
```

这里裸用了 `window`，**少了 `typeof window` 守卫**——同一文件里其他 20 多处 `window` 访问都有守卫（例如 `api.ts:66`、`api.ts:78`、`api.ts:105`）。在没有 `window` 全局的环境里，请求发出前就抛 `ReferenceError: window is not defined`。

实测把队列项的实际状态打出来：

```
RESULT: {"attempted":1,"synced":0,"failed":1,"conflicted":0}  requests: 0
QUEUED AFTER: [{"status":"error","lastError":"window is not defined"}]
```

这同时解释了三个现象：`requestCount` 为 0（fetch 从未发出）、`conflicted:1` 变成 `failed:1`（异常被算作失败）、以及那个 5 秒超时（在等一个永远不会发出的请求）。

## 附带修复：测试间的 `window` 污染

`apps/web/src/lib/api.test.mjs` 和 `desktop-resources.test.mjs` 在模块顶层赋值 `globalThis.window = { edgeeverDesktop: ... }`，没有 `location` 且不清理。Bun 的所有测试文件跑在同一进程内，这个 stub 会泄漏到后续文件，导致 `network-status.ts:5` 崩溃：

```
TypeError: undefined is not an object (evaluating 'window.location.hostname')
    at isLoopbackOrigin (apps/web/src/lib/network-status.ts:5:66)
    at isBrowserOffline (apps/web/src/lib/network-status.ts:10:4)
    at listTags (apps/web/src/lib/repository.ts:234:34)
    at apps/web/src/lib/repository.test.mjs:170:31
```

是否触发取决于测试文件的发现顺序，所以**在 Linux 上会挂，在 macOS 上不会**。本 PR 给这两个 stub 补上 `location`。

## 为什么 CI 没发现

现有 workflow 都不跑完整的 `bun test`：

- `deploy-tools.yml` → 只跑 3 个部署相关测试文件
- `desktop-build.yml` → 跑 `test:desktop`（子集，不含 `tests/web-sync-queue.test.ts`）

完整套件目前只在 `sync-edgeever-upstream.yml` 的 `Verify update` 里执行，也就是**只有 Fork 部署用户会撞上**。他们的每日自动更新会卡在这一步，merge 不会被 push，部署一直停在旧版本。

如果需要，我也可以另开一个 PR 给 CI 加上完整 `bun test`。

## 影响范围

只影响非浏览器环境（测试）。真实浏览器里 `window` 一定存在，**不是线上功能 bug**。

## 验证

在当前 `main`（05dbd1d）上，Bun 1.3.14：

- 修复前：296 pass / 3 fail
- 修复后：**299 pass / 0 fail**
- `bun run typecheck` 通过
- `bun run build` 通过
