### PR TITLE
fix: allow scrolling on public share pages

### DIFF
--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -144,6 +144,15 @@ body,
   overflow: hidden;
 }
 
+/* Public share pages are standalone and must scroll the document. */
+html:has(.edgeever-public-share),
+html:has(.edgeever-public-share) body,
+html:has(.edgeever-public-share) #root {
+  height: auto;
+  min-height: 100%;
+  overflow: auto;
+}
+
 html.edgeever-mobile-native-editing,
 html.edgeever-mobile-native-editing body,
 html.edgeever-mobile-native-editing #root {


### PR DESCRIPTION
## Problem

Public share pages (`/share/:token`) cannot scroll when content exceeds the viewport.

The global app CSS sets `overflow: hidden` on `html`, `body`, and `#root` to support the internal-scroll three-pane workspace layout. Standalone share pages inherit this, so content taller than the viewport is clipped with no way to scroll.

## Fix

Restore document scrolling when a public share page is present using the `:has()` selector:

```css
html:has(.edgeever-public-share),
html:has(.edgeever-public-share) body,
html:has(.edgeever-public-share) #root {
  height: auto;
  min-height: 100%;
  overflow: auto;
}
```

`:has()` is supported in Chrome 105+, Safari 15.4+, Firefox 121+, and all modern evergreen browsers.

## Verification

- Before: `document.scrollingElement.scrollHeight` = 441px while article content = 1320px, `scrollable: false`
- After: `scrollable: true`, `window.scrollTo(0, 500)` works, max scroll = 959px